### PR TITLE
feat(coreos): add option to deploy CoreOS nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packer/variables.json
 ansible/group_vars/all.yml
 ansible/inventories/hosts.yml
 ansible/inventories/proxmox.json
+packer/fedora-coreos-server/**.json

--- a/README.md
+++ b/README.md
@@ -27,7 +27,22 @@ cp packer/example-variables.json packer/variables.json
 ```
 Fill in the `packer/variables.json` file with values that are appropriate for your environment.
 
+example:
+```
+{
+    "proxmox_host": "192.168.1.220:8006",
+    "proxmox_node": "main-node",
+    "proxmox_api_user": "root@pam",
+    "proxmox_api_password": "mysecretpass"
+}
+```
+
 ## Create your ubuntu-2004-server template
+Visit the [Ubuntu Download page](https://releases.ubuntu.com/20.04/) website and download the latest server live iso.
+Upload it to your iso storage provider.
+
+Review the [user-data](./packer/ubuntu-20.04-server/user-data) configuration.
+
 ```bash
 cd packer  # Note: packer's 'http_directory' is a relative path
 packer build -var-file="variables.json" ubuntu-2004-server.json
@@ -85,7 +100,7 @@ ansible-playbook kubespray_create_docker_image.yml
 # Run this command if you did the optional step above and wish to use the latest kubespray updates
 DOCKER_IMAGE=kubespray_github
 # Run this command if you wish to use the official kubespray Docker image
-DOCKER_IMAGE=quay.io/kubespray/kubespray:v2.16.0
+DOCKER_IMAGE=quay.io/kubespray/kubespray:v2.17.0
 
 CID=$(docker create ${DOCKER_IMAGE}) && \
 docker cp ${CID}:/kubespray/inventory/sample mycluster && \
@@ -111,9 +126,9 @@ docker exec -it kubespray ansible-playbook -i inventory/mycluster/proxmox.py --u
 ```bash
 mkdir -p $HOME/.kube
 
-ssh ubuntu@10.0.129.175 'mkdir -p $HOME/.kube && sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config'
+IP=192.168.1.133 ssh ubuntu@${IP} 'mkdir -p $HOME/.kube && sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config'
 
-ssh ubuntu@10.0.129.175 'sudo cat $HOME/.kube/config' > $HOME/.kube/config
+IP=192.168.1.133 ssh ubuntu@${IP} 'sudo cat $HOME/.kube/config' > $HOME/.kube/config
 
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 ```

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,3 +3,4 @@ force_valid_group_names = ignore
 interpreter_python = auto
 host_key_checking = False
 inventory = inventories/hosts.yml, inventories/proxmox.py
+timeout = 60

--- a/ansible/group_vars/example-all.yml
+++ b/ansible/group_vars/example-all.yml
@@ -1,5 +1,7 @@
 ansible_python_interpreter: /usr/bin/python3
 
+proxmox_template_name: ubuntu-20.04-server
+
 proxmox_details:
   host_ip: 10.0.128.128
   host_ssh_port: 22

--- a/ansible/proxmox_k8s_new_master_vm.yml
+++ b/ansible/proxmox_k8s_new_master_vm.yml
@@ -3,19 +3,20 @@
 
   tasks:
     - set_fact:
-       id: "{{ range(10000, 99999) | random }}"
+        id: "{{ range(10000, 99999) | random }}"
 
-    - name: Clone ubuntu-20.04-server template
+    - name: Clone server template
       community.general.proxmox_kvm:
         api_user: "{{ proxmox_details.api_user }}"
         api_password: "{{ proxmox_details.api_password }}"
         api_host: "{{ proxmox_details.host_ip }}"
-        clone: ubuntu-20.04-server
+        clone: "{{ proxmox_template_name }}"
         name: k8s-master-{{ id }}
+        timeout: 60
         node: "{{ proxmox_details.node }}"
         storage: "{{ proxmox_details.storage }}"
       register: new_vm
-    
+
     - name: Get new VM's id
       set_fact:
         vmid: "{{ new_vm.msg | regex_replace('.*newid ') | regex_replace(' cloned.*') }}"
@@ -36,13 +37,13 @@
         api_host: "{{ proxmox_details.host_ip }}"
         node: "{{ proxmox_details.node }}"
         vmid: "{{ vmid }}"
-        description: "{\"groups\": [\"kube-master\", \"etcd\", \"k8s_cluster\"]}"
+        description: '{"groups": ["kube-master", "etcd", "k8s_cluster"]}'
         update: true
 
     - name: Add Proxmox host to inventory
       add_host:
-        hostname: '{{ proxmox_details.host_ip }}'
-        ansible_port: '{{ proxmox_details.host_ssh_port }}'
+        hostname: "{{ proxmox_details.host_ip }}"
+        ansible_port: "{{ proxmox_details.host_ssh_port }}"
 
     - name: Fix broken VM boot order to not reboot to PXE. Must be run after first VM boot.
       shell: "qm set {{ vmid }} --boot order=scsi0"
@@ -50,5 +51,5 @@
         ansible_become_password: "{{ proxmox_details.api_password }}"
       become: yes
       become_user: root
-      delegate_to: '{{ proxmox_details.host_ip }}'
+      delegate_to: "{{ proxmox_details.host_ip }}"
       delegate_facts: false

--- a/ansible/proxmox_k8s_new_node_vm.yml
+++ b/ansible/proxmox_k8s_new_node_vm.yml
@@ -5,12 +5,12 @@
     - set_fact:
        id: "{{ range(10000, 99999) | random }}"
 
-    - name: Clone ubuntu-20.04-server template
+    - name: Clone server template
       community.general.proxmox_kvm:
         api_user: "{{ proxmox_details.api_user }}"
         api_password: "{{ proxmox_details.api_password }}"
         api_host: "{{ proxmox_details.host_ip }}"
-        clone: ubuntu-20.04-server
+        clone: "{{ proxmox_template_name }}"
         name: k8s-node-{{ id }}
         node: "{{ proxmox_details.node }}"
         storage: "{{ proxmox_details.storage }}"

--- a/packer/fedora-coreos-kubespray.json
+++ b/packer/fedora-coreos-kubespray.json
@@ -1,0 +1,71 @@
+{
+  "variables": {
+    "proxmox_host": null,
+    "proxmox_node": null,
+    "proxmox_api_user": null,
+    "proxmox_api_password": null,
+    "disk_storage_pool": "raid",
+    "iso_storage_pool": "raid",
+    "core_count": "8",
+    "ignition_suffix": "kubespray",
+    "fedora_coreos_iso_url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live.x86_64.iso",
+    "fedora_coreos_iso_checksum": "49e5288595bbd49447cc77b3fba6798b8e4cb21c44c76312cdb8435346a2097b",
+    "fedora_coreos_raw_url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal.x86_64.raw.xz"
+  },
+  "sensitive-variables": [
+    "proxmox_api_password"
+  ],
+  "builders": [
+    {
+      "type": "proxmox-iso",
+      "proxmox_url": "https://{{ user `proxmox_host` }}/api2/json",
+      "insecure_skip_tls_verify": true,
+      "username": "{{ user `proxmox_api_user` }}",
+      "password": "{{ user `proxmox_api_password` }}",
+      "http_bind_address": "0.0.0.0",
+      "http_port_min": 8942,
+      "http_port_max": 8942,
+      "template_description": "Fedora CoreOS {{ user `ignition_suffix` }}. Built on {{ isotime \"2006-01-02T15:04:05Z\" }}",
+      "node": "{{user `proxmox_node`}}",
+      "network_adapters": [
+        {
+          "model": "virtio",
+          "bridge": "vmbr0"
+        }
+      ],
+      "disks": [
+        {
+          "type": "scsi",
+          "disk_size": "32G",
+          "storage_pool": "{{ user `disk_storage_pool` }}",
+          "storage_pool_type": "directory",
+          "format": "qcow2"
+        }
+      ],
+      "iso_url": "{{user `fedora_coreos_iso_url`}}",
+      "iso_checksum": "sha256:{{user `fedora_coreos_iso_checksum`}}",
+      "iso_storage_pool": "{{user `iso_storage_pool`}}",
+      "http_directory": "fedora-coreos-server",
+      "unmount_iso": true,
+      "boot": "order=scsi0;ide2",
+      "boot_wait": "5s",
+      "onboot": "true",
+      "qemu_agent": "true",
+      "boot_command": [
+        "<enter>",
+        "<wait30s>",
+        "sudo /usr/bin/coreos-installer install --insecure-ignition -I http://{{ .HTTPIP }}:{{ .HTTPPort }}/ignition-{{ user `ignition_suffix` }}.json -u {{user `fedora_coreos_raw_url`}} /dev/sda && reboot",
+        "<enter>",
+        "<wait1m>"
+      ],
+      "vm_name": "fedora-coreos34-{{ user `ignition_suffix` }}",
+      "memory": "8192",
+      "sockets": "1",
+      "cores": "{{ user `core_count` }}",
+      "os": "l26",
+      "ssh_username": "core",
+      "ssh_private_key_file": "/home/jonas/.ssh/id_rsa",
+      "ssh_timeout": "20m"
+    }
+  ]
+}

--- a/packer/fedora-coreos-server/ignition-kubespray.yaml
+++ b/packer/fedora-coreos-server/ignition-kubespray.yaml
@@ -1,0 +1,59 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+      password_hash: $6$mysalt$gInlfvR5R61K1nUndOdi2TbBwuWdljVSa3DabDNDwoqf4.uNbmBhJ2obbwekZ.vJ4hZW.O2tf4ItAEnjw1gvD0
+      ssh_authorized_keys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRB3PGNkKo2WS4e40jFR3wGg6Eu3ZxwfoSbClAPj2tu4HFUdDoe+hH+peAhdF6Khrv/20pK1Va8IDdJTYzWXNNBwiq+GC0SFvurJVUFJ+Dt3UJAfs1il+/BZeMCZLCjOKKirlAH48bEPoc4SSuG0Lcia2NHJbkcJ4vfH4hsN8H8I3QJY5+eT//HjfkXVgphonh1sKCKJvMPf8mCw1jJrqJ87fEnxNM7FooqV5+IUxoIJ1PHsZKijohSz/e2hsZJy/XpQYIh6S10lzEYli1xvjhOX4t5yKGjM+x9BXVxg0SnKeCV4i/VN2t7sQxlBUxXK/T1vqit2NokH/45+YQtsyMKw3TOdJ4ukLI6PVnBV3PukPowR11XqvtEAUxCFLY/42IH8f+nnhEMiKOAMTdG3zsY0eplJwJXmz3gzHGLieKYyVXbKzAZ3k13HH/W6q6IyQd47Owra8NnKrvWJqD14NT4uQvptS5qsohu5oJGvJJJY6mltA8vT8SV9v1L1LxU/lchem8ynV2qoKDtrnW5cuegG0RyjGGbHKpo4xArPIZXqSjPRO4UxofwP8g7EbUNLPTQNV7Ng3WACNRX7z76GjSc/aZW1zrwO1qqXa2Ek51dAJXbSyxUZqIbGv9ad/RbCnxOE2e1dbgsirPAL0Xp5fTh6i4aSiJ6MNLa1zpjZkdcQ=="
+      groups:
+        - wheel
+        - sudo
+storage:
+  files:
+    - path: /etc/sysctl.d/reverse-path-filter.conf
+      contents:
+        inline: |
+          net.ipv4.conf.all.rp_filter=1
+    - path: /etc/locale.conf
+      mode: 0644
+      contents:
+        inline: |
+          LANG=de_DE.UTF-8
+          LC_MESSAGES=C
+    # https://github.com/coreos/fedora-coreos-docs/blob/master/modules/ROOT/pages/faq.adoc#why-does-ssh-stop-working-after-upgrading-to-fedora-33
+    - path: /etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
+      mode: 0600
+      contents:
+        inline: |
+          PubkeyAcceptedKeyTypes=+ssh-rsa
+
+systemd:
+  units:
+    - name: rpm-ostree-install-kube-dependencies.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Layer kube dependencies with rpm-ostree
+        # We run after `systemd-machine-id-commit.service` to ensure that
+        # `ConditionFirstBoot=true` services won't rerun on the next boot.
+        After=systemd-machine-id-commit.service
+        After=network-online.target
+        # We run before `zincati.service` to avoid conflicting rpm-ostree
+        # transactions.
+        Before=zincati.service
+        ConditionPathExists=!/var/lib/kube-prereq.stamp
+        OnFailure=emergency.target
+        OnFailureJobMode=replace-irreversibly
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/bin/rpm-ostree install --allow-inactive python python3-libselinux ethtool ipset conntrack-tools qemu-guest-agent
+        ExecStart=/bin/touch /var/lib/kube-prereq.stamp
+        ExecStart=/bin/systemctl --no-block reboot
+        StandardOutput=kmsg+console
+        StandardError=kmsg+console
+
+        [Install]
+        WantedBy=multi-user.target

--- a/packer/ubuntu-2004-server.json
+++ b/packer/ubuntu-2004-server.json
@@ -3,9 +3,15 @@
     "proxmox_host": null,
     "proxmox_node": null,
     "proxmox_api_user": null,
-    "proxmox_api_password": null
+    "proxmox_api_password": null,
+    "disk_storage_pool": "raid",
+    "iso_storage_pool": "raid",
+    "core_count": "8",
+    "ubuntu_iso_name": "ubuntu-20.04.3-live-server-amd64.iso"
   },
-  "sensitive-variables": ["proxmox_api_password"],
+  "sensitive-variables": [
+    "proxmox_api_password"
+  ],
   "builders": [
     {
       "type": "proxmox-iso",
@@ -13,7 +19,6 @@
       "insecure_skip_tls_verify": true,
       "username": "{{ user `proxmox_api_user` }}",
       "password": "{{ user `proxmox_api_password` }}",
-
       "template_description": "Ubuntu 20.04 server. Built on {{ isotime \"2006-01-02T15:04:05Z\" }}",
       "node": "{{user `proxmox_node`}}",
       "network_adapters": [
@@ -26,13 +31,12 @@
         {
           "type": "scsi",
           "disk_size": "32G",
-          "storage_pool": "raid",
+          "storage_pool": "{{ user `disk_storage_pool` }}",
           "storage_pool_type": "directory",
           "format": "qcow2"
         }
       ],
-
-      "iso_file": "raid:iso/ubuntu-20.04.3-live-server-amd64.iso",
+      "iso_file": "{{ user `iso_storage_pool` }}:iso/{{ user `ubuntu_iso_name` }}",
       "http_directory": "ubuntu-20.04-server",
       "unmount_iso": true,
       "boot": "order=scsi0;ide2",
@@ -43,13 +47,11 @@
         "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
         "--- <enter>"
       ],
-
       "vm_name": "ubuntu-20.04-server",
       "memory": "8192",
       "sockets": "1",
-      "cores": "8",
+      "cores": "{{ user `core_count` }}",
       "os": "l26",
-
       "ssh_username": "ubuntu",
       "ssh_password": "ubuntu",
       "ssh_timeout": "20m"
@@ -59,7 +61,9 @@
     {
       "pause_before": "20s",
       "type": "shell",
-      "environment_vars": ["DEBIAN_FRONTEND=noninteractive"],
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive"
+      ],
       "inline": [
         "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
         "date > provision.txt",


### PR DESCRIPTION
I really liked the repo but wanted to use Fedora CoreOS as my underlying OS for the K8S cluster. PR makes some variables configurable and adds the option to provision CoreOS nodes.

I set every default variable to point towards the ubuntu config so it should not break any existing automation build around this repository.

As I'm also participating in the Hacktoberfest Event I would highly appreciate it if you could add the `hacktoberfest-accepted` label to this PR